### PR TITLE
Added support for removing 'import' expressions. #1

### DIFF
--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -23,6 +23,24 @@ describe(__filename, () => {
       `);
     });
 
+    it('should remove import call expression by extensions', () => {
+      babelEql(`
+        import './index.less';
+        import * as babel from 'babel';
+      `, {
+        plugins: [
+          [
+            babelPluginTransformRequireIgnore,
+            {
+              extensions: ['.less', '.sass']
+            }
+          ]
+        ]
+      }).eql(`
+        import * as babel from 'babel';
+      `);
+    });
+
     it('should not process when remove require call expression in assignment expression', () => {
       expect(() => {
         const source = `
@@ -40,6 +58,63 @@ describe(__filename, () => {
           ]
         });
       }).to.throw('./index.less should not be assign to variable.');
+    });
+
+    it('should not process when remove import expression in default imports', () => {
+      expect(() => {
+        const source = `
+          import myCss from './index.less';
+          import * as babel from 'babel';
+        `;
+        babelEql(source, {
+          plugins: [
+            [
+              babelPluginTransformRequireIgnore,
+              {
+                extensions: ['.less']
+              }
+            ]
+          ]
+        });
+      }).to.throw('./index.less should not be imported using default imports.');
+    });
+
+    it('should not process when remove import expression in named imports', () => {
+      expect(() => {
+        const source = `
+          import { myCss } from './index.less';
+          import * as babel from 'babel';
+        `;
+        babelEql(source, {
+          plugins: [
+            [
+              babelPluginTransformRequireIgnore,
+              {
+                extensions: ['.less']
+              }
+            ]
+          ]
+        });
+      }).to.throw('./index.less should not be imported using named imports.');
+    });
+
+    it('should not process when remove import expression in namespace imports', () => {
+      expect(() => {
+        const source = `
+          import * as myCss from './index.less';
+          import * as babel from 'babel';
+        `;
+        babelEql(source, {
+          plugins: [
+            [
+              babelPluginTransformRequireIgnore,
+              {
+                extensions: ['.less']
+              }
+            ]
+          ]
+        });
+      }).to.throw('./index.less should not be imported using namespace imports.');
     });
 
     it('should remove require call expression in other block', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,37 @@ export default function () {
             }
           }
         }
+      },
+
+      ImportDeclaration: {
+        enter(nodePath, { opts }) {
+          const extensionsInput = [].concat(opts.extensions || []);
+
+          if (extensionsInput.length === 0) {
+            return;
+          }
+          const extensions = extensionsInput.map(extFix);
+
+          if (extensions.indexOf(path.extname(nodePath.node.source.value)) > -1) {
+            const specifiers = nodePath.get('specifiers');
+
+            if (specifiers.length) {
+              const specifier = specifiers[specifiers.length - 1];
+
+              if (specifier.isImportDefaultSpecifier()) {
+                throw new Error(`${nodePath.node.source.value} should not be imported using default imports.`);
+              }
+              if (specifier.isImportSpecifier()) {
+                throw new Error(`${nodePath.node.source.value} should not be imported using named imports.`);
+              }
+              if (specifier.isImportNamespaceSpecifier()) {
+                throw new Error(`${nodePath.node.source.value} should not be imported using namespace imports.`);
+              }
+            }
+
+            nodePath.remove();
+          }
+        }
       }
     }
   };


### PR DESCRIPTION
Added support for removing `import` expressions. It will works even when babel `es2015` preset is not attached.